### PR TITLE
Fix enum case in relation status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -210,7 +210,7 @@ components:
           description: Business relation type.
         relationStatus:
           type: string
-          enum: [active, terminated]
+          enum: [Active, Terminated]
           default: Active
           description: Status of the business relation.
         crmCode:


### PR DESCRIPTION
## Summary
- unify case in `relationStatus` schema enumeration

## Testing
- `ruby -e 'require "yaml"; require "date"; YAML.load_file("openapi.yaml", permitted_classes: [Date]); puts "ok"'`

------
https://chatgpt.com/codex/tasks/task_e_683ffea01b508326bb21fdcb2a949d88