### PR TITLE
Add pytest OpenAPI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Authorization: Bearer <your_token_here>
 - Swagger UI (self-hosted)
 - GitHub Pages for free hosting
 
+## 🧪 Testing
+
+Automated tests verify that the `openapi.yaml` specification is valid. To run
+them, install the test dependencies and execute `pytest`:
+
+```bash
+pip install openapi-spec-validator pytest
+pytest
+```
+
 ---
 
 ## 📄 License

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,12 @@
+import pytest
+
+yaml = pytest.importorskip('yaml')
+openapi_spec_validator = pytest.importorskip('openapi_spec_validator')
+from openapi_spec_validator import validate_spec
+
+
+def test_openapi_yaml_validates():
+    with open('openapi.yaml', 'r') as f:
+        spec = yaml.safe_load(f)
+    # validate_spec raises an exception if the spec is invalid
+    validate_spec(spec)


### PR DESCRIPTION
## Summary
- add a minimal pytest to validate `openapi.yaml` using `openapi-spec-validator`
- document how to run the tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840063f95888326af1abd28b859df3a