### PR TITLE
Add Switzerland production API server to OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -46,7 +46,9 @@ info:
 
 servers:
   - url: https://www.riskquadrant.com/api
-    description: API for Production environment
+    description: API for Production environment - Luxembourg
+  - url: https://www.riskquadrant.ch/api
+    description: API for Production environment - Switzerland
   - url: https://www.rq-test.com/api
     description: API for Test environment (for sandbox integration)    
 


### PR DESCRIPTION
### Motivation
- The OpenAPI spec only referenced a single production URL and the test URL, but the deployment has two production endpoints (Luxembourg and Switzerland) and the spec should expose both.

### Description
- Updated `openapi.yaml` `servers` list by changing the description for `https://www.riskquadrant.com/api` to "API for Production environment - Luxembourg" and adding `https://www.riskquadrant.ch/api` with description "API for Production environment - Switzerland".

### Testing
- Ran `git diff -- openapi.yaml` and `git status --short` (both succeeded), committed the change, and attempted to validate the YAML with `python` using `yaml.safe_load` which failed because the `PyYAML` module is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9c97c6508326822b70338eb2a072)