### PR TITLE
Update OpenAPI docs for business relation links endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2038,6 +2038,72 @@ paths:
                 code: 500
 
   /v1.1/business-relations/{crmCode}/links:
+    get:
+      summary: Retrieve business relation links
+      tags:
+        - Business relations links
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: crmCode
+          required: true
+          schema:
+            type: string
+          description: The CRM code of the primary business relation.
+      responses:
+        '200':
+          description: Links retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  links:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BusinessRelationLink'
+                example:
+                  status: success
+                  links:
+                    - linkedCrmCode: MZ001
+                      role: Director
+                    - linkedCrmCode: SH002
+                      role: Shareholder
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "Unauthorized - Missing or invalid token"
+                code: 401
+        '404':
+          description: Business relation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "Internal Server Error"
+                code: 500
+
     post:
       summary: Link multiple business relations to a primary one
       tags:
@@ -2113,6 +2179,11 @@ paths:
 
     delete:
       summary: Delete business relation links
+      description: >
+        Deletes links for a given primary business relation. If the request body contains one
+        or more objects with `linkedCrmCode` and `role`, only those specific links are deleted.
+        If the request body is empty, or if no `linkedCrmCode` is provided, all links for the
+        specified primary business relation are deleted.
       tags:
         - Business relations links
       security:
@@ -2125,16 +2196,22 @@ paths:
             type: string
           description: The CRM code of the primary business relation.
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BusinessRelationLinkDeleteRequest'
-            example:
-              - linkedCrmCode: MZ001
-                role: Director
-              - linkedCrmCode: SH002
-                role: Shareholder
+            examples:
+              deleteSpecificLinks:
+                summary: Delete specific links
+                value:
+                  - linkedCrmCode: MZ001
+                    role: Director
+                  - linkedCrmCode: SH002
+                    role: Shareholder
+              deleteAllLinks:
+                summary: Delete all links
+                value: []
       responses:
         '200':
           description: Links deleted successfully
@@ -2157,6 +2234,13 @@ paths:
                         role:
                           type: string
                           example: Director
+                example:
+                  status: success
+                  deletedLinks:
+                    - linkedCrmCode: MZ001
+                      role: Director
+                    - linkedCrmCode: SH002
+                      role: Shareholder
         '400':
           description: Invalid input
           content:


### PR DESCRIPTION
### Motivation
- Provide a new read endpoint to return all links for a primary business relation (`GET /v1.1/business-relations/{crmCode}/links`).
- Clarify delete semantics so callers can delete specific links or all links via the existing `DELETE /v1.1/business-relations/{crmCode}/links` endpoint.
- Make the DELETE request body optional and add examples and response payload examples for both selective and all-links deletion.

### Description
- Added `GET /v1.1/business-relations/{crmCode}/links` under the existing "Business relations links" tag with `bearerAuth`, a required `crmCode` path parameter, a `200` response schema containing `status` and `links`, and documented `400`, `401`, `404`, and `500` error responses using existing `ErrorResponse` and `BusinessRelationLink` schemas.
- Updated `DELETE /v1.1/business-relations/{crmCode}/links` description to document that provided `linkedCrmCode`+`role` objects delete only those links while an empty body or missing `linkedCrmCode` deletes all links.
- Made the DELETE `requestBody` optional and added two examples: `deleteSpecificLinks` (list of objects) and `deleteAllLinks` (empty array), preserving existing `BusinessRelationLinkDeleteRequest` schema usage.
- Added an explicit `200` response example for the DELETE response showing `deletedLinks` in the same format as other endpoint examples; no other files were modified.

### Testing
- No automated unit or integration tests were executed against the modified specification.
- The change is documentation-only in `openapi.yaml` and intended for CI/validation by existing API spec tooling or pipelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c23e70bb0832682d7a826ada7cb0c)